### PR TITLE
Remove print receipt when cancelling of payment

### DIFF
--- a/assets/js/pay.js
+++ b/assets/js/pay.js
@@ -449,7 +449,7 @@ function cancelPayment(outcome) {
 
   // Wait four seconds, then quit window, giving the cashier a chance to try
   // again.
-  setTimeout(declineStep, 4000, '<div>CANCELLED</div>')
+  setTimeout(declineStep, 4000)
 }
 
 function showClose() {


### PR DESCRIPTION
This would remove printing of receipt when vend users hit the cancel button before completing a payment cycle.